### PR TITLE
在docker中启动多个gunicorn进程时，偶发异常"File exists',导致服务启动失败

### DIFF
--- a/nacos/client.py
+++ b/nacos/client.py
@@ -259,7 +259,7 @@ class NacosClient:
         if not logDir.endswith(os.path.sep):
             logDir += os.path.sep
         if not os.path.exists(logDir):
-            os.makedirs(logDir)
+            os.makedirs(logDir, exist_ok=True)
 
         if log_rotation_backup_count is None:
             log_rotation_backup_count = 7


### PR DESCRIPTION
在docker中启动多个gunicorn进程时，偶发异常"File exists: '/root/logs/nacos/', 导致服务启动失。推测是因为其中1个gunicorn进程已经创建了logs文件夹，从而导致其他的进程创建文件夹失败。
增加参数“exist_ok=True”，如果文件夹已存在，就不再创建

异常堆栈信息如下：
[2024-07-15 16:43:03 +0800] [9] [INFO] Booting worker with pid: 9
[2024-07-15 16:43:06 +0800] [9] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/arbiter.py", line 609, in spawn_worker
    worker.init_process()
  File "/usr/local/lib/python3.10/dist-packages/uvicorn/workers.py", line 68, in init_process
    super().init_process()
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/workers/base.py", line 134, in init_process
    self.load_wsgi()
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/workers/base.py", line 146, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/app/wsgiapp.py", line 58, in load
    return self.load_wsgiapp()
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/util.py", line 371, in import_app
    mod = importlib.import_module(module)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/data/app/server/main.py", line 34, in <module>
    server = init_server()
  File "/data/app/server/main.py", line 26, in init_server
    bootstrap.init(fastapi_server)
  File "/data/app/server/app/bootstrap/initialize.py", line 30, in init
    nacos_reg()
  File "/data/app/server/app/bootstrap/nacos_register.py", line 29, in nacos_reg
    client = NacosClient(server_addresses=global_app_config.nacos_server,namespace=global_app_config.nacos_namespace,
  File "/usr/local/lib/python3.10/dist-packages/nacos/client.py", line 292, in __init__
    self.initLog(logDir)
  File "/usr/local/lib/python3.10/dist-packages/nacos/client.py", line 277, in initLog
    os.makedirs(logDir)
  File "/usr/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/root/logs/nacos/'
[2024-07-15 16:43:06 +0800] [9] [INFO] Worker exiting (pid: 9)
[2024-07-15 16:43:06 +0800] [8] [INFO] Started server process [8]
[2024-07-15 16:43:06 +0800] [8] [INFO] Waiting for application startup.
[2024-07-15 16:43:06 +0800] [8] [INFO] Application startup complete.
[2024-07-15 16:43:06 +0800] [7] [ERROR] Worker (pid:9) exited with code 3
[2024-07-15 16:43:06 +0800] [8] [INFO] Shutting down
[2024-07-15 16:43:07 +0800] [8] [INFO] Waiting for application shutdown.
[2024-07-15 16:43:07 +0800] [8] [INFO] Application shutdown complete.
[2024-07-15 16:43:07 +0800] [8] [INFO] Finished server process [8]
[2024-07-15 16:43:07 +0800] [7] [ERROR] Worker (pid:8) was sent SIGTERM!
[2024-07-15 16:43:07 +0800] [7] [ERROR] Shutting down: Master
[2024-07-15 16:43:07 +0800] [7] [ERROR] Reason: Worker failed to boot.