### PR TITLE
rm redundant errors

### DIFF
--- a/nacos/client.py
+++ b/nacos/client.py
@@ -813,35 +813,38 @@ class NacosClient:
         logger.info("[init-pulling] init completed")
 
     def _process_polling_result(self):
-        while True:
-            cache_key, content, md5 = self.notify_queue.get()
-            logger.info("[process-polling-result] receive an event:%s" % cache_key)
-            wl = self.watcher_mapping.get(cache_key)
-            if not wl:
-                logger.warning("[process-polling-result] no watcher on %s, ignored" % cache_key)
-                continue
+        try:
+            while True:
+                cache_key, content, md5 = self.notify_queue.get()
+                logger.info("[process-polling-result] receive an event:%s" % cache_key)
+                wl = self.watcher_mapping.get(cache_key)
+                if not wl:
+                    logger.warning("[process-polling-result] no watcher on %s, ignored" % cache_key)
+                    continue
 
-            data_id, group, namespace = parse_key(cache_key)
-            plain_content = content
+                data_id, group, namespace = parse_key(cache_key)
+                plain_content = content
 
-            params = {
-                "data_id": data_id,
-                "group": group,
-                "namespace": namespace,
-                "raw_content": content,
-                "content": plain_content,
-            }
-            for watcher in wl:
-                if not watcher.last_md5 == md5:
-                    logger.info(
-                        "[process-polling-result] md5 changed since last call, calling %s with changed md5: %s ,params: %s"
-                        % (watcher.callback.__name__, md5, params))
-                    try:
-                        self.callback_tread_pool.apply(watcher.callback, (params,))
-                    except Exception as e:
-                        logger.exception("[process-polling-result] exception %s occur while calling %s " % (
-                            str(e), watcher.callback.__name__))
-                    watcher.last_md5 = md5
+                params = {
+                    "data_id": data_id,
+                    "group": group,
+                    "namespace": namespace,
+                    "raw_content": content,
+                    "content": plain_content,
+                }
+                for watcher in wl:
+                    if not watcher.last_md5 == md5:
+                        logger.info(
+                            "[process-polling-result] md5 changed since last call, calling %s with changed md5: %s ,params: %s"
+                            % (watcher.callback.__name__, md5, params))
+                        try:
+                            self.callback_tread_pool.apply(watcher.callback, (params,))
+                        except Exception as e:
+                            logger.exception("[process-polling-result] exception %s occur while calling %s " % (
+                                str(e), watcher.callback.__name__))
+                        watcher.last_md5 = md5
+        except (EOFError, OSError) as e:
+            logger.exception(f"[process-polling-result] break when receive exception of {type(e)}")
 
     @staticmethod
     def _inject_version_info(headers):


### PR DESCRIPTION
When I manually kill the main process, the `multiprocessing.queue` still attempts to read data, which results in an `EOFError`, followed by a long trace of error messages. These messages aren't particularly important, but they frequently clutter my terminal screen, especially during local debugging. 
So, I tried to suppress the errors caused by EOFError, but I'm not entirely sure if this will have other unintended consequences.

error messages:
```
INFO:     Started server process [85480]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:7760 (Press CTRL+C to quit)
^CINFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [85480]
Exception in thread Thread-15 (_process_polling_result):
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/songguodong/workspace/analysis-agent-python/.venv/lib/python3.11/site-packages/nacos/client.py", line 818, in _process_polling_result
    cache_key, content, md5 = self.notify_queue.get()
                              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/queues.py", line 103, in get
    res = self._recv_bytes()
          ^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/connection.py", line 216, in recv_bytes
    buf = self._recv_bytes(maxlength)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/connection.py", line 430, in _recv_bytes
    buf = self._recv(4)
          ^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/connection.py", line 399, in _recv
    raise EOFError
EOFError
```