### PR TITLE
resolve watcher high cpu usage

### DIFF
--- a/nacos/client.py
+++ b/nacos/client.py
@@ -749,6 +749,7 @@ class NacosClient:
             cache_pool[cache_key] = CacheData(cache_key, self)
 
         while cache_list:
+            time.sleep(1)
             unused_keys = set(cache_pool.keys())
             contains_init_key = False
             probe_update_string = ""
@@ -786,10 +787,8 @@ class NacosClient:
                 logger.info("[do-pulling] following keys are changed from server %s" % truncate(str(changed_keys)))
             except NacosException as e:
                 logger.error("[do-pulling] nacos exception: %s, waiting for recovery" % str(e))
-                time.sleep(1)
             except Exception as e:
                 logger.exception("[do-pulling] exception %s occur, return empty list, waiting for recovery" % str(e))
-                time.sleep(1)
 
             for cache_key, cache_data in cache_pool.items():
                 cache_data.is_init = False


### PR DESCRIPTION
version: 2.0.1
python version: 3.8.13
operate system: CentOS Linux release 7.9.2009

while syntax cause high cpu use, because of the different mechanism, below code when run in linux, it will use hign cpu. windows normal


test code:

import nacos
import yaml
from flask import Flask

app = Flask(__name__)


class NacosCofig:
    namespace = "public"
    group = "DEFAULT_GROUP"
    server_name = "test"
    server_port = "7004"
    data_id = "test"  
    server_addresses = "http://127.0.0.1:8848"
    server_ip = "127.0.0.1"


client = nacos.NacosClient(NacosCofig.server_addresses, namespace=NacosCofig.namespace)
yaml_data = yaml.load(client.get_config(NacosCofig.data_id, NacosCofig.group), Loader=yaml.FullLoader)


def start_nacos():
    global yaml_data, client
    client.add_config_watcher(NacosCofig.data_id, NacosCofig.group, _modify_config_cb)


def _modify_config_cb(config):
    global yaml_data
    yaml_data = yaml.load(client.get_config(NacosCofig.data_id, NacosCofig.group), Loader=yaml.FullLoader)
    print(yaml_data)


def service_register():
    global client
    client.add_naming_instance(NacosCofig.server_name, NacosCofig.server_ip, NacosCofig.server_port,
                               ephemeral=False, group_name=NacosCofig.group, heartbeat_interval=5)


if __name__ == '__main__':
    start_nacos()
    service_register()
    app.run(debug=False, port=7004, host="0.0.0.0")

before:
![image](https://github.com/user-attachments/assets/ba3b2e07-8804-45ab-8082-ee034db02fcd)
after:
![image](https://github.com/user-attachments/assets/cdddc4da-c4cd-4e4d-b11e-e48bd219b185)




