### PR TITLE
fix: remove unnecessary constructor causing model_validate error

### DIFF
--- a/v2/nacos/transport/model/internal_request.py
+++ b/v2/nacos/transport/model/internal_request.py
@@ -8,16 +8,12 @@ CLIENT_DETECTION_REQUEST_TYPE = "ClientDetectionRequest"
 
 
 class InternalRequest(Request, ABC):
-    def __init__(self):
-        super().__init__()
 
     def get_module(self) -> str:
         return 'internal'
 
 
 class HealthCheckRequest(InternalRequest):
-    def __init__(self):
-        super().__init__()
 
     def get_request_type(self):
         return "HealthCheckRequest"


### PR DESCRIPTION
```
2025-03-18 09:38:52,748 INFO receive stream server request, connection_id:1742261840622_172.27.200.156_48765, original info: metadata {
  type: "ClientDetectionRequest"
  clientIp: "10.10.35.1"
}
body {
  value: "{"headers":{},"requestId":"5817","module":"internal"}"
}

2025-03-18 09:39:51,107 ERROR [1742261840622_172.27.200.156_48765] handle server request occur exception: InternalRequest.__init__() got an unexpected keyword argument 'headers'
```