### PR TITLE
fix: do_sync_req args error

### DIFF
--- a/nacos/client.py
+++ b/nacos/client.py
@@ -425,7 +425,7 @@ class NacosClient:
             params["type"] = config_type
 
         try:
-            resp = self._do_sync_req("/nacos/v1/cs/configs", None, None, params,
+            resp = self._do_sync_req("/nacos/v1/cs/configs", None, params, None,
                                      timeout or self.default_timeout, "POST")
             c = resp.read()
             logger.info("[publish] publish content, group:%s, data_id:%s, server response:%s" % (


### PR DESCRIPTION
raise error :
```
 line 742, in _do_sync_req
    raise NacosRequestException("All server are not available")
nacos.exception.NacosRequestException: All server are not available
```