### PR TITLE
fix(mcp): 修正 MCP 端点规格类名拼写错误

### DIFF
--- a/test/ai_client_test.py
+++ b/test/ai_client_test.py
@@ -13,7 +13,7 @@ from v2.nacos.ai.model.ai_param import GetMcpServerParam, ReleaseMcpServerParam,
 	ReleaseAgentCardParam, GetAgentCardParam, RegisterAgentEndpointParam, \
 	SubscribeAgentCardParam, DeregisterAgentEndpointParam
 from v2.nacos.ai.model.mcp.mcp import McpServerBasicInfo, \
-	McpServerRemoteServiceConfig, McpEndpointSpce, McpServerDetailInfo
+	McpServerRemoteServiceConfig, McpEndpointSpec, McpServerDetailInfo
 from v2.nacos.ai.model.mcp.registry import ServerVersionDetail
 from v2.nacos.ai.nacos_ai_service import NacosAIService
 
@@ -162,7 +162,7 @@ class TestAIClientV2(unittest.IsolatedAsyncioTestCase):
 								exportPath="/test/export/path",
 						),
 				),
-				mcp_endpoint_spec = McpEndpointSpce(
+				mcp_endpoint_spec = McpEndpointSpec(
 						type= AIConstants.MCP_ENDPOINT_TYPE_REF,
 						data={
 								"groupName":"group1",

--- a/v2/nacos/ai/model/ai_param.py
+++ b/v2/nacos/ai/model/ai_param.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from v2.nacos.ai.model.a2a.a2a import AgentCardDetailInfo
 from v2.nacos.ai.model.ai_constant import AIConstants
 from v2.nacos.ai.model.mcp.mcp import McpServerBasicInfo, McpToolSpecification, \
-	McpEndpointSpce, McpServerDetailInfo
+	McpEndpointSpec, McpServerDetailInfo
 
 
 class GetMcpServerParam(BaseModel):
@@ -24,7 +24,7 @@ class ReleaseMcpServerParam(BaseModel):
 	# Tool specification defining the tools provided by MCP server
 	tool_spec: Optional[McpToolSpecification] = None
 	# Endpoint specification for MCP server network configuration
-	mcp_endpoint_spec: Optional[McpEndpointSpce] = None
+	mcp_endpoint_spec: Optional[McpEndpointSpec] = None
 
 
 class RegisterMcpServerEndpointParam(BaseModel):

--- a/v2/nacos/ai/model/ai_request.py
+++ b/v2/nacos/ai/model/ai_request.py
@@ -6,7 +6,7 @@ from a2a.types import AgentCard
 from v2.nacos.ai.model.a2a.a2a import AgentEndpoint
 from v2.nacos.ai.model.ai_constant import AIConstants
 from v2.nacos.ai.model.mcp.mcp import McpServerBasicInfo, McpToolSpecification, \
-	McpEndpointSpce
+	McpEndpointSpec
 from v2.nacos.common.constants import Constants
 from v2.nacos.transport.model.rpc_request import Request
 
@@ -126,7 +126,7 @@ class ReleaseMcpServerRequest(AbstractMcpRequest):
 	# Tool specification defining the capabilities of the MCP server
 	toolSpecification: Optional[McpToolSpecification] = None
 	# Endpoint specification for accessing the MCP server
-	endpointSpecification: Optional[McpEndpointSpce] = None
+	endpointSpecification: Optional[McpEndpointSpec] = None
 
 	def get_request_type(self) -> str:
 		"""Returns the release MCP server request type"""

--- a/v2/nacos/ai/model/mcp/mcp.py
+++ b/v2/nacos/ai/model/mcp/mcp.py
@@ -171,7 +171,7 @@ class McpServerDetailInfo(McpServerBasicInfo):
 	namespaceId: Optional[str] = None
 
 
-class McpEndpointSpce(BaseModel):
+class McpEndpointSpec(BaseModel):
 	"""Specification for MCP server endpoint configuration"""
 	# Endpoint type: Should be AIConstants.MCP_ENDPOINT_TYPE_DIRECT or AIConstants.MCP_ENDPOINT_TYPE_REF
 	# DIRECT: specify address and port directly

--- a/v2/nacos/ai/remote/ai_grpc_client_proxy.py
+++ b/v2/nacos/ai/remote/ai_grpc_client_proxy.py
@@ -20,7 +20,7 @@ from v2.nacos.ai.model.cache.agent_info_cache import AgentInfoCacheHolder
 from v2.nacos.ai.model.cache.mcp_server_info_cache import \
 	McpServerInfoCacheHolder
 from v2.nacos.ai.model.mcp.mcp import McpServerBasicInfo, McpToolSpecification, \
-	McpEndpointSpce, McpServerDetailInfo
+	McpEndpointSpec, McpServerDetailInfo
 from v2.nacos.ai.redo.ai_grpc_redo_service import AIGrpcRedoService
 from v2.nacos.common.constants import Constants
 from v2.nacos.common.nacos_exception import SERVER_ERROR, SERVER_NOT_IMPLEMENTED
@@ -147,7 +147,7 @@ class AIGRPCClientProxy:
 		response = await self.request_ai_server(request, QueryMcpServerResponse)
 		return response.mcpServerDetailInfo
 
-	async def release_mcp_server(self,server_spec: McpServerBasicInfo, tool_spec: McpToolSpecification, endpoint_spec: McpEndpointSpce):
+	async def release_mcp_server(self,server_spec: McpServerBasicInfo, tool_spec: McpToolSpecification, endpoint_spec: McpEndpointSpec):
 		self.logger.info(
 			f"[{self.uuid}] release mcp server: {server_spec.name}, version {server_spec.versionDetail.version}")
 		if not self.is_ability_supported_by_server(AbilityKey.SERVER_MCP_REGISTRY):


### PR DESCRIPTION
- 将 McpEndpointSpce 类名更正为 McpEndpointSpec
- 更新所有引用该类的文件中的导入和使用
- 修正测试文件中实例化错误类名的问题

Change-Id: Idff8c925c78d8aa537b877f4f2cc333a834a0817