### PR TITLE
fix(ai): 修复MCP服务器端点注册参数传递错误

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ class UploadCommand(Command):
 
 setup(
     name="nacos-sdk-python",
-    version="3.0.1",
+    version="3.0.2",
     packages=find_packages(
         exclude=["test", "*.tests", "*.tests.*", "tests.*", "tests"]),
     url="https://github.com/nacos-group/nacos-sdk-python",

--- a/v2/nacos/__init__.py
+++ b/v2/nacos/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 
 from .common.client_config import (KMSConfig,
                                    GRPCConfig,

--- a/v2/nacos/ai/nacos_ai_service.py
+++ b/v2/nacos/ai/nacos_ai_service.py
@@ -82,7 +82,7 @@ class NacosAIService(NacosClient):
 
 		instance.check_instance_is_legal()
 
-		return await self.grpc_client_proxy.register_mcp_server_endpoint(param.mcp_name, param.version, param.port,param.version)
+		return await self.grpc_client_proxy.register_mcp_server_endpoint(param.mcp_name, param.address, param.port, param.version)
 
 
 	async def subscribe_mcp_server(self, param: SubscribeMcpServerParam) -> McpServerDetailInfo:

--- a/v2/nacos/common/constants.py
+++ b/v2/nacos/common/constants.py
@@ -13,7 +13,7 @@ class Constants:
 
     LABEL_MODULE = "module"
 
-    CLIENT_VERSION = "Nacos-Python-Client:v3.0.1"
+    CLIENT_VERSION = "Nacos-Python-Client:v3.0.2"
 
     DATA_IN_BODY_VERSION = 204
 


### PR DESCRIPTION
- 修正了register_mcp_server_endpoint方法中参数传递错误，将param.version替换为param.address
- 更新客户端版本号从3.0.1到3.0.2
- 同步更新setup.py中的版本号信息

Change-Id: I4331e31d1938a11187f1094022a099cb2c6d1a41