### PR TITLE
fix(ai): 修复 Agent 注册后断连重连后无法重新注册的问题

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ class UploadCommand(Command):
 
 setup(
     name="nacos-sdk-python",
-    version="3.0.2",
+    version="3.0.3",
     packages=find_packages(
         exclude=["test", "*.tests", "*.tests.*", "tests.*", "tests"]),
     url="https://github.com/nacos-group/nacos-sdk-python",

--- a/v2/nacos/__init__.py
+++ b/v2/nacos/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.2"
+__version__ = "3.0.3"
 
 from .common.client_config import (KMSConfig,
                                    GRPCConfig,

--- a/v2/nacos/common/constants.py
+++ b/v2/nacos/common/constants.py
@@ -13,7 +13,7 @@ class Constants:
 
     LABEL_MODULE = "module"
 
-    CLIENT_VERSION = "Nacos-Python-Client:v3.0.2"
+    CLIENT_VERSION = "Nacos-Python-Client:v3.0.3"
 
     DATA_IN_BODY_VERSION = 204
 


### PR DESCRIPTION
- 在AI gRPC重做服务中添加代理端点重做方法
- 实现代理端点注册、注销和删除的重做逻辑
- 添加代理端点重做数据的查找和移除功能
- 增加代理端点重做状态检查方法
- 更新客户端版本号从3.0.2到3.0.3
- 同步更新setup.py中的版本信息