### PR TITLE
fix(naming-v2): 简化实例排序逻辑

### DIFF
--- a/v2/nacos/naming/cache/service_info_cache.py
+++ b/v2/nacos/naming/cache/service_info_cache.py
@@ -127,11 +127,7 @@ class ServiceInfoCache:
 
     @staticmethod
     def sort_instances(instances: List[Instance]) -> List[Instance]:
-        def instance_key(instance: Instance) -> (int, int):
-            ip_num = int(''.join(instance.ip.split('.')))
-            return ip_num, instance.port
-
-        return sorted(instances, key=instance_key)
+        return sorted(instances, key=lambda inst: (inst.ip, inst.port))
 
     async def register_callback(self, service_name: str, clusters: str, callback_func_wrapper: SubscribeCallbackFuncWrapper):
         await self.sub_callback_manager.add_callback_func(service_name, clusters, callback_func_wrapper)


### PR DESCRIPTION
- 移除自定义 instance_key 函数，改用 lambda 表达式直接排序
- 排序键从 IP 地址数字转换改为直接使用 IP 字符串和端口, 作为字符串处理