### PR TITLE
fix incorrect usage of stop function

### DIFF
--- a/v2/nacos/naming/nacos_naming_service.py
+++ b/v2/nacos/naming/nacos_naming_service.py
@@ -230,4 +230,4 @@ class NacosNamingService(NacosClient):
 
     async def shutdown(self) -> None:
         await self.grpc_client_proxy.close_client()
-        await self.service_info_updater.stop()
+        self.service_info_updater.stop()


### PR DESCRIPTION
Fix incorrect async usage of `ServiceInfoUpdater.stop()`

---

# PR Description

## Background

`ServiceInfoUpdater.stop()` is implemented as a **synchronous method**, but it was mistakenly awaited in the `shutdown()` coroutine:

```python
await self.service_info_updater.stop()
```

Since `stop()` does not return a coroutine or awaitable object, this leads to incorrect async usage and may cause runtime errors such as:

```
TypeError: object NoneType can't be used in 'await' expression
```

---

## Root Cause

`ServiceInfoUpdater.stop()` is defined as:

```python
def stop(self):
    """Stop service updating"""
    self.stop_event.set()
```

It performs a simple synchronous state update and does not involve any async operations.

However, it was incorrectly treated as an async function inside:

```python
async def shutdown(self) -> None:
    await self.grpc_client_proxy.close_client()
    await self.service_info_updater.stop()  # ❌ incorrect
```

---

## Changes Made

* Removed `await` from the synchronous `stop()` call.
* Updated `shutdown()` implementation to:

```python
async def shutdown(self) -> None:
    await self.grpc_client_proxy.close_client()
    self.service_info_updater.stop()
```

