### PR TITLE
fix(ai): convert sync-only async methods to sync def

### DIFF
--- a/v2/nacos/ai/model/cache/agent_subscribe_manager.py
+++ b/v2/nacos/ai/model/cache/agent_subscribe_manager.py
@@ -31,7 +31,7 @@ class AgentSubscribeManager:
 			if not self.subscribers[key]:
 				del self.subscribers[key]
 
-	async def is_subscribed(self, agent_name:str, version:str) -> bool:
+	def is_subscribed(self, agent_name:str, version:str) -> bool:
 		key = build_agent_key(agent_name, version)
 		if key not in self.subscribers:
 			return False

--- a/v2/nacos/ai/model/cache/mcp_server_subscribe_manager.py
+++ b/v2/nacos/ai/model/cache/mcp_server_subscribe_manager.py
@@ -29,7 +29,7 @@ class McpServerSubscribeManager:
 			if not self.subscribers[key]:
 				del self.subscribers[key]
 
-	async def is_subscribed(self, mcp_name:str, version:str) -> bool:
+	def is_subscribed(self, mcp_name:str, version:str) -> bool:
 		key = build_mcp_server_key(mcp_name, version)
 		if key not in self.subscribers:
 			return False

--- a/v2/nacos/ai/nacos_ai_service.py
+++ b/v2/nacos/ai/nacos_ai_service.py
@@ -169,7 +169,7 @@ class NacosAIService(NacosClient):
 			return
 		await self.agent_subscribe_manager.deregister_subscriber(
 			param.agent_name, param.version, param.subscribe_callback)
-		if not await self.agent_subscribe_manager.is_subscribed(param.agent_name, param.version):
+		if not self.agent_subscribe_manager.is_subscribed(param.agent_name, param.version):
 			await self.grpc_client_proxy.unsubscribe_agent(param.agent_name, param.version)
 
 	async def shutdown(self):

--- a/v2/nacos/ai/remote/ai_grpc_client_proxy.py
+++ b/v2/nacos/ai/remote/ai_grpc_client_proxy.py
@@ -301,5 +301,5 @@ class AIGRPCClientProxy:
 		self.logger.info("close Nacos python ai grpc client...")
 		await self.rpc_client.shutdown()
 
-	async def is_enabled(self):
+	def is_enabled(self):
 		return self.rpc_client.is_running()


### PR DESCRIPTION
- McpServerSubscribeManager.is_subscribed(): was async but only does dict lookup, called without await in nacos_ai_service.py causing unsubscribe logic to never execute (coroutine object is always truthy)
- AgentSubscribeManager.is_subscribed(): same pattern, changed for consistency and removed unnecessary await at call site
- AIGRPCClientProxy.is_enabled(): was async but only calls sync rpc_client.is_running(), called without await in ai_grpc_redo_service.py (4 places) causing redo operations to proceed even when connection is down