### PR TITLE
refactor(naming): remove unnecessary async from is_subscribed methods

### DIFF
--- a/v2/nacos/naming/cache/service_info_cache.py
+++ b/v2/nacos/naming/cache/service_info_cache.py
@@ -135,5 +135,5 @@ class ServiceInfoCache:
     async def deregister_callback(self, service_name: str, clusters: str, callback_func_wrapper: SubscribeCallbackFuncWrapper):
         await self.sub_callback_manager.remove_callback_func(service_name, clusters, callback_func_wrapper)
 
-    async def is_subscribed(self, service_name: str, clusters: str) -> bool:
-        return await self.sub_callback_manager.is_subscribed(service_name, clusters)
+    def is_subscribed(self, service_name: str, clusters: str) -> bool:
+        return self.sub_callback_manager.is_subscribed(service_name, clusters)

--- a/v2/nacos/naming/cache/service_info_updater.py
+++ b/v2/nacos/naming/cache/service_info_updater.py
@@ -33,7 +33,7 @@ class ServiceInfoUpdater:
 				# 遍历所有服务
 				for key, service in self.service_info_holder.service_info_map.items():
 					# 获取上次更新时间
-					if not await self.service_info_holder.is_subscribed(
+					if not self.service_info_holder.is_subscribed(
 							get_group_name(service.name,service.groupName),service.clusters):
 						continue
 

--- a/v2/nacos/naming/cache/subscribe_manager.py
+++ b/v2/nacos/naming/cache/subscribe_manager.py
@@ -12,7 +12,7 @@ class SubscribeManager:
         self.callback_func_wrapper_map: Dict[str, List[SubscribeCallbackFuncWrapper]] = {}
         self.mux = asyncio.Lock()
 
-    async def is_subscribed(self, service_name: str, clusters: str) -> bool:
+    def is_subscribed(self, service_name: str, clusters: str) -> bool:
         key = get_service_cache_key(service_name, clusters)
         return key in self.callback_func_wrapper_map
 

--- a/v2/nacos/naming/nacos_naming_service.py
+++ b/v2/nacos/naming/nacos_naming_service.py
@@ -222,7 +222,7 @@ class NacosNamingService(NacosClient):
         callback_wrapper = SubscribeCallbackFuncWrapper(cluster_selector, request.subscribe_callback)
         await self.service_info_holder.deregister_callback(get_group_name(request.service_name, request.group_name),
                                                            "", callback_wrapper)
-        if not await self.service_info_holder.is_subscribed(get_group_name(request.service_name, request.group_name), ""):
+        if not self.service_info_holder.is_subscribed(get_group_name(request.service_name, request.group_name), ""):
             await self.grpc_client_proxy.unsubscribe(request.service_name, request.group_name, "")
 
     async def server_health(self) -> bool:


### PR DESCRIPTION
SubscribeManager.is_subscribed() and ServiceInfoCache.is_subscribed() were declared as async but only perform synchronous dict lookups. Remove async/await to accurately reflect the synchronous nature of these operations.