### PR TITLE
fix(grpc): handle bi-stream disconnection with existing reconnect mechanism

### DIFF
--- a/v2/nacos/transport/grpc_client.py
+++ b/v2/nacos/transport/grpc_client.py
@@ -16,7 +16,7 @@ from v2.nacos.transport.model.internal_response import ServerCheckResponse
 from v2.nacos.transport.model.rpc_request import Request
 from v2.nacos.transport.model.server_info import ServerInfo
 from v2.nacos.transport.nacos_server_connector import NacosServerConnector
-from v2.nacos.transport.rpc_client import RpcClient, ConnectionType
+from v2.nacos.transport.rpc_client import RpcClient, RpcClientStatus, ConnectionType
 
 
 class GrpcClient(RpcClient):
@@ -143,16 +143,24 @@ class GrpcClient(RpcClient):
                     f"{grpc_connection.get_connection_id()} failed to send response:{response.get_response_type()}, ackId:{request.requestId},error:{str(e)}")
 
     async def _server_request_watcher(self, grpc_conn: GrpcConnection):
-        async for payload in grpc_conn.bi_stream_send():
-            try:
-                self.logger.info("receive stream server request, connection_id:%s, original info: %s"
-                                 % (grpc_conn.get_connection_id(), str(payload)))
-                request = GrpcUtils.parse(payload)
-                if request:
-                    await self._handle_server_request(request, grpc_conn)
+        try:
+            async for payload in grpc_conn.bi_stream_send():
+                try:
+                    self.logger.info("receive stream server request, connection_id:%s, original info: %s"
+                                     % (grpc_conn.get_connection_id(), str(payload)))
+                    request = GrpcUtils.parse(payload)
+                    if request:
+                        await self._handle_server_request(request, grpc_conn)
 
-            except Exception as e:
-                self.logger.error(f"[{grpc_conn.connection_id}] handle server request occur exception: {e}")
+                except Exception as e:
+                    self.logger.error(f"[{grpc_conn.connection_id}] handle server request occur exception: {e}")
+        except Exception as e:
+            self.logger.warning(f"[{grpc_conn.connection_id}] bi stream broken: {e}")
+            if not self.is_shutdown():
+                async with self.lock:
+                    if self.is_running():
+                        self.rpc_client_status = RpcClientStatus.UNHEALTHY
+                await self.switch_server_async(None, False)
 
     @staticmethod
     async def _shunt_down_channel(channel):


### PR DESCRIPTION
## What is the purpose of the change

Fixes https://github.com/nacos-group/nacos-sdk-python/issues/252

This is a revised approach to #253, based on @Sunrisea's [review feedback](https://github.com/nacos-group/nacos-sdk-python/pull/253#issuecomment-2711770088). The original PR implemented a custom reconnect mechanism (`_reconnect` + `_server_request_watcher_new`) which bypassed the existing `RpcClient` reconnect flow, causing `current_connection` not to be updated. This PR takes a minimal approach by reusing the existing reconnect mechanism.

## Brief changelog

fix(grpc): handle bi-stream disconnection with existing reconnect mechanism

- Wrap `_server_request_watcher`'s `async for` loop with an outer `try/except` to catch stream disconnection exceptions (e.g. `AioRpcError`)
- On stream break, mark client status as `UNHEALTHY` and call `switch_server_async()` to trigger the existing reconnect flow in `RpcClient`
- This ensures `current_connection` is properly updated, all connection listeners are notified, and capability negotiation is not bypassed

Supersedes #253.