### PR TITLE
ci: add GitHub Actions workflow for lint and smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [master, feature/v2]
+  pull_request:
+    branches: [master, feature/v2]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - run: pip install ruff==0.15.5
+      - run: ruff check --select F --ignore F401 --exclude "*/grpcauto/*" v2/
+
+  smoke-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.11', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -r requirements.txt
+      - name: Smoke test v1 module
+        if: hashFiles('nacos/__init__.py') != ''
+        run: python -c "import nacos; print('v1 import ok')"
+        env:
+          PYTHONPATH: .
+      - name: Smoke test v2 module
+        run: python -c "import v2.nacos; print('v2 import ok')"
+        env:
+          PYTHONPATH: .


### PR DESCRIPTION
## What is the purpose of the change

Closes https://github.com/nacos-group/nacos-sdk-python/issues/305

Add a lightweight CI pipeline to catch code-breaking issues before merge. Based on the direction approved by @Sunrisea in #305, and informed by industry research on similar SDK projects (boto3, dubbo-python, openai-python, nacos-sdk-go).

## Brief changelog

ci: add GitHub Actions workflow for lint and smoke test

- **lint job**: ruff check with pyflakes rules (`F`) on `v2/` directory, ignoring `F401` (unused imports) for now, excluding auto-generated `grpcauto/` directory
- **smoke-test job**: Python 3.9/3.11/3.13 matrix, install dependencies and verify module imports (`import v2.nacos`, conditionally `import nacos` on `feature/v2`)
- Both branches (`master` and `feature/v2`) use the same workflow file

> Note: A companion PR with identical content targets `master` — see #309.