### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,10 +8,9 @@ assignees: ''
 
 ### Environment
 
-- **SDK Version**: (e.g., V2 / V3)
-- **SDK Package Version**: (e.g., 2.0.5)
+- **SDK Package Version**: (e.g., 3.2.0b1)
 - **Python Version**: (e.g., 3.10 / 3.12 / 3.13)
-- **Nacos Server Version**: (e.g., 2.4.0)
+- **Nacos Server Version**: (e.g., 3.0.3)
 - **OS**: (e.g., Ubuntu 22.04 / macOS 15 / Windows 11)
 
 ### Describe the Bug

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+### Environment
+
+- **SDK Version**: (e.g., V2 / V3)
+- **SDK Package Version**: (e.g., 2.0.5)
+- **Python Version**: (e.g., 3.10 / 3.12 / 3.13)
+- **Nacos Server Version**: (e.g., 2.4.0)
+- **OS**: (e.g., Ubuntu 22.04 / macOS 15 / Windows 11)
+
+### Describe the Bug
+
+A clear and concise description of what the bug is.
+
+### Steps to Reproduce
+
+1.
+2.
+3.
+
+### Minimal Reproducible Code
+
+```python
+# Paste your code here
+```
+
+### Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+### Actual Behavior
+
+A clear and concise description of what actually happened.
+
+### Error Logs / Stack Trace
+
+```
+Paste any relevant logs or stack traces here
+```
+
+### Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://nacos.io/docs/latest/what-is-nacos/
+    about: Please check the Nacos documentation before asking a question.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+### SDK Version
+
+- [ ] V2
+- [ ] V3
+- [ ] Both
+
+### Description
+
+A clear and concise description of the feature you'd like.
+
+### Use Case
+
+Describe the problem or use case that this feature would address.
+
+### Proposed Solution
+
+A clear and concise description of what you want to happen.
+
+### Alternatives Considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional Context
+
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,12 +6,6 @@ labels: enhancement
 assignees: ''
 ---
 
-### SDK Version
-
-- [ ] V2
-- [ ] V3
-- [ ] Both
-
 ### Description
 
 A clear and concise description of the feature you'd like.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -6,10 +6,6 @@ labels: question
 assignees: ''
 ---
 
-### SDK Version
-
-V2 / V3
-
 ### Description
 
 A clear and concise description of your question.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,29 @@
+---
+name: Question
+about: Ask a question about usage or configuration
+title: "[Question] "
+labels: question
+assignees: ''
+---
+
+### SDK Version
+
+V2 / V3
+
+### Description
+
+A clear and concise description of your question.
+
+### What Have You Tried
+
+Describe what you've already tried or researched.
+
+### Relevant Code or Configuration
+
+```python
+# Paste your code here if applicable
+```
+
+### Additional Context
+
+Add any other context about the question here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,3 +19,9 @@
 ### How has this been tested?
 
 <!-- Describe the testing you have done. -->
+
+### Checklist
+
+- [ ] Unit tests added/updated
+- [ ] Documentation updated (if needed)
+- [ ] No breaking changes (or described above)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+### What type of PR is this?
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Enhancement
+- [ ] Refactoring
+- [ ] Documentation
+- [ ] CI/CD
+- [ ] Other
+
+### What does this PR do?
+
+<!-- A brief description of the changes. -->
+
+### Which issue(s) does this PR fix?
+
+<!-- Link to the related issue(s). e.g., Fixes #123 -->
+
+### How has this been tested?
+
+<!-- Describe the testing you have done. -->


### PR DESCRIPTION
### What type of PR is this?

- [x] CI/CD

### What does this PR do?

- Add issue templates for bug reports, feature requests, and questions
- Add pull request template to standardize PR descriptions
- Add template config with link to Nacos documentation

| Template | Purpose |
|----------|---------|
| `ISSUE_TEMPLATE/bug_report.md` | Collect environment info, reproduction steps, and error logs |
| `ISSUE_TEMPLATE/feature_request.md` | Describe use case and proposed solution (V2/V3) |
| `ISSUE_TEMPLATE/question.md` | Usage questions with context |
| `ISSUE_TEMPLATE/config.yml` | Allow blank issues + link to Nacos docs |
| `pull_request_template.md` | Standardize PR type, description, related issues, and testing |

### Which issue(s) does this PR fix?

N/A

### How has this been tested?

Verified templates render correctly on GitHub.