### PR TITLE
fix: improve reconnect recovery with async lock fix and immediate redo trigger

### DIFF
--- a/v2/nacos/redo/abstract_redo_service.py
+++ b/v2/nacos/redo/abstract_redo_service.py
@@ -22,6 +22,7 @@ class AbstractRedoService(ConnectionEventListener,ABC):
 
 	async def on_connected(self) -> None:
 		self._connected = True
+		await self.start_redo_task()
 
 	async def on_disconnect(self) -> None:
 		self._connected = False

--- a/v2/nacos/transport/rpc_client.py
+++ b/v2/nacos/transport/rpc_client.py
@@ -459,7 +459,7 @@ class ConnectResetRequestHandler(IServerRequestHandler):
             return None
 
         try:
-            with self.rpc_client.lock:
+            async with self.rpc_client.lock:
                 if self.rpc_client.is_running():
                     if request.server_ip.strip():
                         server_info = ServerInfo(request.server_ip, int(request.server_port))


### PR DESCRIPTION
### What type of PR is this?

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Other

### What does this PR do?

Two small fixes to improve reconnect recovery after gRPC connection drops:

1. **Fix async lock bug in `ConnectResetRequestHandler`**: The handler used synchronous `with` on an `asyncio.Lock`, which does not actually acquire the lock (`asyncio.Lock.__enter__` is a no-op without `await acquire()`). Changed to `async with` to properly guard the status check and server switch when handling `ConnectResetRequest` from the server.

2. **Trigger redo immediately on reconnect**: After gRPC reconnection, `on_connected()` only set `self._connected = True`. The redo task polled `_execute_redo_channel` with a 30-second timeout, so instance re-registration could be delayed up to 30 seconds. Now `on_connected()` also calls the existing `start_redo_task()` method to signal the channel immediately, waking the redo task to re-register instances without delay.

### Which issue(s) does this PR fix?

Related to https://github.com/alibaba/nacos/issues/14106

### How has this been tested?

- Code review and static analysis of the async lock usage
- Traced the redo task flow to confirm `start_redo_task()` → `_execute_redo_channel.put(None)` → `_execute_redo_task` wakes up → checks `_connected` (already True) → calls `redo_task()` to re-register instances
- Verified no other synchronous lock usages remain in `rpc_client.py`

### Checklist

- [ ] Unit tests added/updated
- [x] Documentation updated (if needed)
- [x] No breaking changes (or described above)