### PR TITLE
ci: add tag-triggered release workflow with PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+# Release automation: push a version tag (e.g. 3.2.1) to build, publish to
+# PyPI and create the GitHub Release in one go.
+#
+# PyPI auth uses Trusted Publishing (OIDC), no token stored in the repo.
+# One-time setup required by a PyPI project owner:
+#   PyPI -> nacos-sdk-python -> Publishing -> Add a new publisher (GitHub):
+#     Owner: nacos-group / Repository: nacos-sdk-python
+#     Workflow name: release.yml / Environment name: pypi
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]*.[0-9]*.[0-9]*'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify version consistency
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          SETUP_VER=$(python3 -c "import re; print(re.search(r'version=\"([^\"]+)\"', open('setup.py').read()).group(1))")
+          CLIENT_VER=$(python3 -c "import re; print(re.search(r'CLIENT_VERSION = \"Nacos-Python-Client:v([^\"]+)\"', open('v2/nacos/common/constants.py').read()).group(1))")
+          echo "tag=${TAG} setup.py=${SETUP_VER} constants.py=${CLIENT_VER}"
+          if [ "${TAG}" != "${SETUP_VER}" ] || [ "${TAG}" != "${CLIENT_VER}" ]; then
+            echo "::error::Version mismatch: tag=${TAG}, setup.py=${SETUP_VER}, constants.py CLIENT_VERSION=${CLIENT_VER}"
+            exit 1
+          fi
+
+  build:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Build sdist and wheel
+        run: |
+          pip install build
+          python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/nacos-sdk-python/${{ github.ref_name }}/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          ARGS=(--title "${TAG}" --generate-notes)
+          if echo "${TAG}" | grep -qE '(a|b|rc)[0-9]*$'; then
+            ARGS+=(--prerelease)
+          fi
+          gh release create "${TAG}" "${ARGS[@]}"


### PR DESCRIPTION
### What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [x] CI/CD
- [ ] Other

### What does this PR do?

当前发布流程全手动（本地 `setup.py upload` 上传 PyPI + 手动推 tag + 网页创建 Release），漏掉任何一步都不会有提示——例如 3.2.0 已发布到 PyPI、tag 已推送，但 GitHub Release 一直缺失（见 #328）。

本 PR 新增 `release.yml`，**推送版本 tag 即自动完成全部发布动作**，包含 4 个串联 job：

1. **verify** — 校验 tag 名 == `setup.py` 的 `version` == `constants.py` 的 `CLIENT_VERSION`，不一致 fail fast（历史上 `3.2.0b1`/`3.2.0` 两处均有同步，校验可行）
2. **build** — `python -m build` 构建 sdist + wheel。顺带修正 wheel tag：本包要求 Python >=3.10，但旧流程 `--universal` 会产出 py2.py3 通用 wheel，现改为正确的 `py3-none-any`
3. **publish-pypi** — 通过 [PyPI Trusted Publishing (OIDC)](https://docs.pypi.org/trusted-publishers/) 发布，仓库无需存放任何 PyPI token
4. **github-release** — `--generate-notes` 自动创建 GitHub Release（格式与现有 3.0.x Release 一致）；tag 以 `a`/`b`/`rc` 结尾自动标记 pre-release

**需要 PyPI 项目 owner 做一次性配置**（已写在 workflow 文件头部注释）：

> PyPI → `nacos-sdk-python` → Publishing → Add a new publisher (GitHub)：
> - Owner: `nacos-group`
> - Repository: `nacos-sdk-python`
> - Workflow name: `release.yml`
> - Environment name: `pypi`

配置完成前 workflow 不会误发布：未配置 publisher 时 `publish-pypi` job 会直接失败，不影响现有手动流程。

### Which issue(s) does this PR fix?

Ref #328

### How has this been tested?

GitHub Actions 无法在 fork 外预跑 tag 触发，已对每个 job 的核心逻辑做本地验证：

- **YAML 语法**：`yaml.safe_load` 通过
- **verify 逻辑**：对当前代码（3.2.0）模拟 `TAG=3.2.0` 判定通过；版本提取正则对 `setup.py` / `constants.py` 实测有效
- **pre-release 判断**：`3.2.0` → stable，`3.2.0b1` / `3.3.0rc1` / `3.2.0a2` → prerelease，四个用例全部正确
- **build**：本地实跑 `python -m build`，成功产出 `nacos_sdk_python-3.2.0.tar.gz` 与 `nacos_sdk_python-3.2.0-py3-none-any.whl`（sdist 含 `requirements.txt`/`README.md`，`MANIFEST.in` 已覆盖）
- **publish-pypi**：采用 PyPA 官方 action `pypa/gh-action-pypi-publish@release/v1` 的标准用法（build/publish 分离 + artifact 传递 + environment + `id-token: write`）

### Checklist

- [ ] Unit tests added/updated（纯 CI 配置，无单测）
- [x] Documentation updated (if needed)（Trusted Publishing 配置步骤已写入 workflow 头部注释及 #328）
- [x] No breaking changes (or described above)
