### PR TITLE
fix: expose update_cache_when_empty builder option

### DIFF
--- a/test/test_client_config_builder.py
+++ b/test/test_client_config_builder.py
@@ -1,0 +1,20 @@
+import unittest
+
+from v2.nacos.common.client_config_builder import ClientConfigBuilder
+
+
+class ClientConfigBuilderTest(unittest.TestCase):
+    def test_update_cache_when_empty_default_keeps_false(self):
+        client_config = ClientConfigBuilder().build()
+
+        self.assertFalse(client_config.update_cache_when_empty)
+
+    def test_update_cache_when_empty_can_be_configured(self):
+        client_config = ClientConfigBuilder().update_cache_when_empty(True).build()
+
+        self.assertTrue(client_config.update_cache_when_empty)
+
+    def test_update_cache_when_empty_keeps_builder_chainable(self):
+        builder = ClientConfigBuilder()
+
+        self.assertIs(builder.update_cache_when_empty(False), builder)

--- a/v2/nacos/common/client_config_builder.py
+++ b/v2/nacos/common/client_config_builder.py
@@ -93,6 +93,10 @@ class ClientConfigBuilder:
         self._config.load_cache_at_start = load_cache_at_start
         return self
 
+    def update_cache_when_empty(self, update_cache_when_empty: bool) -> "ClientConfigBuilder":
+        self._config.set_update_cache_when_empty(update_cache_when_empty)
+        return self
+
     def app_conn_labels(self, app_conn_labels: dict) -> "ClientConfigBuilder":
         if self._config.app_conn_labels is None:
             self._config.app_conn_labels = {}


### PR DESCRIPTION
## Summary
- Expose `ClientConfig.update_cache_when_empty` through `ClientConfigBuilder.update_cache_when_empty(...)`.
- Keep the existing default behavior unchanged.
- Add unit tests for the default value, configured value, and builder chaining.

## Test plan
- [x] `./.venv/bin/python -m unittest test.test_client_config_builder -v`
- [x] `./.venv/bin/python -m compileall v2/nacos/common/client_config_builder.py test/test_client_config_builder.py`
- [x] `./.venv/bin/python -m unittest test.test_client_config_builder test.test_naming_service_cache -v`
- [x] Local Nacos smoke test: default `update_cache_when_empty=False` does not receive the empty callback after the last instance is deregistered; `.update_cache_when_empty(True)` receives `[]`.

Related to https://github.com/alibaba/nacos/issues/15419