### PR TITLE
fix #333: pass agent card query parameters correctly

### DIFF
--- a/test/test_nacos_ai_service.py
+++ b/test/test_nacos_ai_service.py
@@ -1,0 +1,23 @@
+import unittest
+
+from v2.nacos.ai.model.ai_param import GetAgentCardParam
+from v2.nacos.ai.nacos_ai_service import NacosAIService
+
+
+class RecordingAgentCardProxy:
+	async def get_agent_card(self, agent_name, version, registration_type):
+		return agent_name, version, registration_type
+
+
+class TestNacosAIService(unittest.IsolatedAsyncioTestCase):
+	async def test_get_agent_card_preserves_version_and_registration_type(self):
+		service = object.__new__(NacosAIService)
+		service.grpc_client_proxy = RecordingAgentCardProxy()
+
+		result = await service.get_agent_card(GetAgentCardParam(
+			agent_name="demo-agent",
+			version="1.2.3",
+			registration_type="url",
+		))
+
+		self.assertEqual(("demo-agent", "1.2.3", "url"), result)

--- a/v2/nacos/ai/nacos_ai_service.py
+++ b/v2/nacos/ai/nacos_ai_service.py
@@ -136,7 +136,11 @@ class NacosAIService(NacosClient):
 	async def get_agent_card(self, param: GetAgentCardParam) -> AgentCardDetailInfo:
 		if not param.agent_name or len(param.agent_name) == 0:
 			raise NacosException(INVALID_PARAM, "agentName is required")
-		return await self.grpc_client_proxy.get_agent_card(param.agent_name, param.registration_type, param.version)
+		return await self.grpc_client_proxy.get_agent_card(
+			agent_name=param.agent_name,
+			version=param.version,
+			registration_type=param.registration_type,
+		)
 
 	async def release_agent_card(self, param: ReleaseAgentCardParam):
 		if not param.agent_card:


### PR DESCRIPTION
## Summary

- preserve `GetAgentCardParam.version` and `registration_type` when querying an Agent Card
- use explicit keyword arguments when forwarding the request to the gRPC proxy
- add a focused regression test for the parameter mapping

## Root cause

`NacosAIService.get_agent_card()` passed `registration_type` in the proxy's `version` position and `version` in the `registration_type` position. Queries that specified either field therefore generated an incorrect `QueryAgentCardRequest`.

## Test plan

- [x] `python -m unittest test.test_nacos_ai_service test.test_skill_and_prompt test.test_client_config_builder test.test_naming_service_cache`
- [x] `ruff check --select F --ignore F401 --exclude '*/grpcauto/*' v2/ test/test_nacos_ai_service.py`
- [x] `python -m compileall -q v2/nacos/ai test/test_nacos_ai_service.py`
- [x] `git diff --check`

Closes #333
